### PR TITLE
Add golangci-lint to workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,5 +21,10 @@ jobs:
       with:
         go-version: '1.22'
 
+    - name: Lint
+      uses: golangci/golangci-lint-action@v6
+      with:
+        version: 'latest'
+
     - name: Test
       run: go test -v ./...

--- a/main_test.go
+++ b/main_test.go
@@ -13,7 +13,7 @@ import (
 func path(s string) *filter.Path {
 	p, err := filter.ParsePath([]byte(s))
 	if err != nil {
-		fmt.Println(fmt.Sprintf("Failed to parse %s occurred by %s", s, err))
+		fmt.Printf("Failed to parse %s occurred by %s\n", s, err)
 	}
 	return &p
 }


### PR DESCRIPTION
By introducing a linter into your project, you can reduce the cost of code checking.
The golangci-lint we will introduce this time is a tool that runs linters at high speed and is well known in the Go community.

The default linter is here: https://golangci-lint.run/usage/linters/#enabled-by-default

---
(Copilot summary)

This pull request primarily focuses on improving the Go workflow and updating the error logging in tests. The most significant changes include the addition of a linting step in the GitHub Actions workflow for Go and the modification of an error logging statement in `main_test.go`.

Linting and Testing:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR24-R28): Added a new linting step to the GitHub Actions workflow for Go. This uses the `golangci/golangci-lint-action@v6` with the latest version. This will help in maintaining the code quality by catching and reporting any linting issues before the code is merged.

Error Logging:

* [`main_test.go`](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eL16-R16): Updated the error logging statement in the `path` function. The `fmt.Println(fmt.Sprintf())` has been replaced with `fmt.Printf()`, which is a more efficient way to format and print the log message.