### PR TITLE
Update the version of setup-go to v5 and Get the go version from go.mod

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,9 +17,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version-file: 'go.mod'
 
     - name: Lint
       uses: golangci/golangci-lint-action@v6


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow for the Go application in the `.github/workflows/go.yml` file. The changes involve updating the version of the `setup-go` action and changing the way the Go version is specified.

Here are the key changes:

* Updated the `setup-go` action from version `v4` to `v5`. This update may include bug fixes, new features, or other improvements.
* Instead of hardcoding the Go version to `1.22`, the workflow now uses the version specified in the `go.mod` file. This makes it easier to manage the Go version across different parts of the project.