### PR TITLE
fix: module name

### DIFF
--- a/_example/go.mod
+++ b/_example/go.mod
@@ -1,0 +1,16 @@
+module github.com/ivixvi/scim-patch/_example
+
+go 1.22.5
+
+replace github.com/ivixvi/scim-patch => ../
+
+require (
+	github.com/elimity-com/scim v0.0.0-20240320110924-172bf2aee9c8
+	github.com/ivixvi/scim-patch v0.0.0-00010101000000-000000000000
+)
+
+require (
+	github.com/di-wu/parser v0.2.2 // indirect
+	github.com/di-wu/xsd-datetime v1.0.0 // indirect
+	github.com/scim2/filter-parser/v2 v2.2.0 // indirect
+)

--- a/_example/go.sum
+++ b/_example/go.sum
@@ -1,0 +1,8 @@
+github.com/di-wu/parser v0.2.2 h1:I9oHJ8spBXOeL7Wps0ffkFFFiXJf/pk7NX9lcAMqRMU=
+github.com/di-wu/parser v0.2.2/go.mod h1:SLp58pW6WamdmznrVRrw2NTyn4wAvT9rrEFynKX7nYo=
+github.com/di-wu/xsd-datetime v1.0.0 h1:vZoGNkbzpBNoc+JyfVLEbutNDNydYV8XwHeV7eUJoxI=
+github.com/di-wu/xsd-datetime v1.0.0/go.mod h1:i3iEhrP3WchwseOBeIdW/zxeoleXTOzx1WyDXgdmOww=
+github.com/elimity-com/scim v0.0.0-20240320110924-172bf2aee9c8 h1:0+BTyxIYgiVAry/P5s8R4dYuLkhB9Nhso8ogFWNr4IQ=
+github.com/elimity-com/scim v0.0.0-20240320110924-172bf2aee9c8/go.mod h1:JkjcmqbLW+khwt2fmBPJFBhx2zGZ8XobRZ+O0VhlwWo=
+github.com/scim2/filter-parser/v2 v2.2.0 h1:QGadEcsmypxg8gYChRSM2j1edLyE/2j72j+hdmI4BJM=
+github.com/scim2/filter-parser/v2 v2.2.0/go.mod h1:jWnkDToqX/Y0ugz0P5VvpVEUKcWcyHHj+X+je9ce5JA=

--- a/_example/handlers.go
+++ b/_example/handlers.go
@@ -10,7 +10,7 @@ import (
 	"github.com/elimity-com/scim/errors"
 	"github.com/elimity-com/scim/optional"
 	"github.com/elimity-com/scim/schema"
-	"github.com/ivixvi/scimpatch"
+	scimpatch "github.com/ivixvi/scim-patch"
 )
 
 type testData struct {

--- a/_example/server.go
+++ b/_example/server.go
@@ -6,7 +6,7 @@ import (
 	"github.com/elimity-com/scim"
 	"github.com/elimity-com/scim/optional"
 	"github.com/elimity-com/scim/schema"
-	"github.com/ivixvi/scimpatch"
+	scimpatch "github.com/ivixvi/scim-patch"
 )
 
 func newTestServer() scim.Server {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ivixvi/scimpatch
+module github.com/ivixvi/scim-patch
 
 go 1.22
 

--- a/scimpatch_test.go
+++ b/scimpatch_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/elimity-com/scim"
 	"github.com/elimity-com/scim/errors"
 	"github.com/elimity-com/scim/schema"
-	"github.com/ivixvi/scimpatch"
+	scimpatch "github.com/ivixvi/scim-patch"
 	filter "github.com/scim2/filter-parser/v2"
 )
 


### PR DESCRIPTION
Fixed the following errors
```
> go get github.com/ivixvi/scim-patch
go: downloading github.com/ivixvi/scim-patch v0.0.0-20240713140849-b0e3e4e7128a
go: github.com/ivixvi/scim-patch@upgrade (v0.0.0-20240713140849-b0e3e4e7128a) requires github.com/ivixvi/scim-patch@v0.0.0-20240713140849-b0e3e4e7128a: parsing go.mod:
        module declares its path as: github.com/ivixvi/scimpatch
```