### PR TITLE
feat: support dot notation for add and replace ops

### DIFF
--- a/dot.go
+++ b/dot.go
@@ -1,0 +1,25 @@
+package scimpatch
+
+import (
+	"strings"
+)
+
+// Resolve an attribute name with dot notation ("name.givenName") to a new scopedMap ("name") and scopedAttr ("givenName")
+// This is used prominently by MS Entra. See https://learn.microsoft.com/en-us/entra/identity/app-provisioning/application-provisioning-config-problem-scim-compatibility#flags-to-alter-the-scim-behavior
+func resolveDotNotationAttribute(scopedMap map[string]interface{}, scopedAttr string) (map[string]interface{}, string) {
+	attrParts := strings.SplitN(scopedAttr, ".", 2)
+	if len(attrParts) == 1 {
+		return scopedMap, scopedAttr
+	}
+
+	if subMap, exists := scopedMap[attrParts[0]]; exists {
+		scopedMap = subMap.(map[string]interface{})
+	} else {
+		subMap := map[string]interface{}{}
+		scopedMap[attrParts[0]] = subMap
+		scopedMap = subMap
+	}
+	scopedAttr = attrParts[1]
+
+	return scopedMap, scopedAttr
+}

--- a/path_not_specified_add_test.go
+++ b/path_not_specified_add_test.go
@@ -199,6 +199,28 @@ func TestPathNotSpecifiedAdd(t *testing.T) {
 			expectedChanged: true,
 		},
 		{
+			name: "Add operation - Core Complex Attributes - dot notation",
+			op: scim.PatchOperation{
+				Op: "add",
+				Value: map[string]interface{}{
+					"name.familyName": "Green",
+				},
+			},
+			data: map[string]interface{}{
+				"name": map[string]interface{}{
+					"familyName": "Blue",
+					"givenName":  "Alice",
+				},
+			},
+			expected: map[string]interface{}{
+				"name": map[string]interface{}{
+					"familyName": "Green",
+					"givenName":  "Alice",
+				},
+			},
+			expectedChanged: true,
+		},
+		{
 			name: "Add operation - Core Singular Attributes - map specified no changed",
 			op: scim.PatchOperation{
 				Op: "add",

--- a/path_not_specified_replace_test.go
+++ b/path_not_specified_replace_test.go
@@ -125,6 +125,44 @@ func TestPathNotSpecifiedReplace(t *testing.T) {
 			expectedChanged: true,
 		},
 		{
+			name: "Replace operation - Core Complex Attributes - dot notation, replacing values",
+			op: scim.PatchOperation{
+				Op: "replace",
+				Value: map[string]interface{}{
+					"name.familyName": "Green",
+				},
+			},
+			data: map[string]interface{}{
+				"name": map[string]interface{}{
+					"familyName": "Blue",
+					"givenName":  "Alice",
+				},
+			},
+			expected: map[string]interface{}{
+				"name": map[string]interface{}{
+					"familyName": "Green",
+					"givenName":  "Alice",
+				},
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "Replace operation - Core Complex Attributes - dot notation, adding value",
+			op: scim.PatchOperation{
+				Op: "replace",
+				Value: map[string]interface{}{
+					"name.familyName": "Green",
+				},
+			},
+			data: map[string]interface{}{},
+			expected: map[string]interface{}{
+				"name": map[string]interface{}{
+					"familyName": "Green",
+				},
+			},
+			expectedChanged: true,
+		},
+		{
 			name: "Replace operation - Core Complex Attributes - no changed.",
 			op: scim.PatchOperation{
 				Op: "replace",

--- a/scimpatch.go
+++ b/scimpatch.go
@@ -158,6 +158,7 @@ func (p *Patcher) pathSpecifiedOperate(
 	// request path is `attr`, `attr.subAttr`
 	case !attr.MultiValued() || op.Path.ValueExpression == nil:
 		scopedMap, scopedAttr := n.GetScopedMap()
+		scopedMap, scopedAttr = resolveDotNotationAttribute(scopedMap, scopedAttr)
 		changed = operator.Direct(ctx, scopedMap, scopedAttr, op.Value)
 		n.ApplyScopedMap(scopedMap)
 	}
@@ -178,7 +179,8 @@ func (p *Patcher) pathUnspecifiedOperate(
 			uriPrefix, ok := p.schemas[attr]
 			// Core Attributes
 			if !ok {
-				if operator.Direct(ctx, data, attr, value) {
+				scopedMap, scopedAttr := resolveDotNotationAttribute(data, attr)
+				if operator.Direct(ctx, scopedMap, scopedAttr, value) {
 					changed = true
 				}
 				continue
@@ -197,7 +199,8 @@ func (p *Patcher) pathUnspecifiedOperate(
 			// if exists, write by every attributes
 			if newUriMap, ok := value.(map[string]interface{}); ok {
 				for scopedAttr, scopedValue := range newUriMap {
-					if operator.Direct(ctx, oldMap, scopedAttr, scopedValue) {
+					scopedMap, scopedAttr := resolveDotNotationAttribute(oldMap, scopedAttr)
+					if operator.Direct(ctx, scopedMap, scopedAttr, scopedValue) {
 						changed = true
 					}
 				}


### PR DESCRIPTION
Hey there! Thanks for taking a stab at scim-patch in golang :+1: 

I noticed that there is no support for the "dot notation", which is prominently used by MS Entra. Here is an example patch operation from their [validator](https://scimvalidator.microsoft.com/):

```
    {
      "op": "replace",
      "value": {
        "externalId": "39be3336-3e88-4c41-80b7-c654ab698a5e",
        "active": true,
        "name.familyName": "Lincoln",
        "name.givenName": "Greg"
      }
```

The `name.familyName` here should be applied to the `familyName` subattribute of `name`. This dot notation has no examples inthe spec unfortunately, but is mentioned in [Section 3.10](https://datatracker.ietf.org/doc/html/rfc7644#section-3.10). There are also some examples of how dot notation is used in the entra [scim compatibility docs](https://learn.microsoft.com/en-us/entra/identity/app-provisioning/application-provisioning-config-problem-scim-compatibility#flags-to-alter-the-scim-behavior), see the "Requests to replace multiple attributes" example with the new feature flag (now enabled by default, I believe).

This PR adds support for the dot notation and some tests for it. I'm not sure the way it is implemented fully matches your architecture, but if it doesn't perhaps this can serve as a starting point.

<details><summary>I also validated that it fixes the relevant step of the entra scim validator.</summary>
<p>

![image](https://github.com/user-attachments/assets/fe479ece-cab2-4365-8111-849218bb1c33)

</p>
</details> 